### PR TITLE
Fix undefined ts in lab one plots

### DIFF
--- a/labs/lab_one.ipynb
+++ b/labs/lab_one.ipynb
@@ -337,7 +337,7 @@
     "        trajectories = simulator.simulate_with_trajectory(x0, timesteps) # (num_trajectories, num_timesteps, ...)\n",
     "        for trajectory_idx in range(trajectories.shape[0]):\n",
     "            trajectory = trajectories[trajectory_idx, :, 0] # (num_timesteps,)\n",
-    "            ax.plot(ts.cpu(), trajectory.cpu())"
+    "            ax.plot(timesteps.cpu(), trajectory.cpu())"
    ]
   },
   {
@@ -503,7 +503,7 @@
     "        trajectories = simulator.simulate_with_trajectory(x0, timesteps) # (num_trajectories, num_timesteps, ...)\n",
     "        for trajectory_idx in range(trajectories.shape[0]):\n",
     "            trajectory = trajectories[trajectory_idx, :, 0] # (num_timesteps,)\n",
-    "            ax.plot(ts.cpu() * time_scale, trajectory.cpu(), label=label)"
+    "            ax.plot(timesteps.cpu() * time_scale, trajectory.cpu(), label=label)"
    ]
   },
   {


### PR DESCRIPTION
## What was broken

Two plotting cells in `labs/lab_one.ipynb` referenced `ts`, which is not defined in those cells, so they failed with `NameError` when run.

## What changed

Both cells now plot against `timesteps`, the variable already returned by `simulator.simulate_with_trajectory` and used by the surrounding code. No other behavior changes.
