### PR TITLE
Fix LangevinFlowSDE diffusion coefficient

### DIFF
--- a/solutions/lab_two_complete.ipynb
+++ b/solutions/lab_two_complete.ipynb
@@ -1714,7 +1714,7 @@
     "        Returns:\n",
     "            - u_t(x|z): shape (batch_size, dim)\n",
     "        \"\"\"\n",
-    "        return self.sigma * torch.randn_like(x)"
+    "        return self.sigma"
    ]
   },
   {


### PR DESCRIPTION
Hi! This PR fixes the duplicate Gaussian sampling typo in the diffusion_coefficient() method of the LangevinFlowSDE class.

The same issue was already corrected in ConditionalVectorFieldSDE, but the identical implementation in LangevinFlowSDE was not updated. This patch applies the same fix to that class.